### PR TITLE
Take parameters for setDadaOpt from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A dada2-based workflow using the Nextflow workflow manager.  The basic pipeline 
       --trimOverhang                {"T","F"}. If "T" (true), "overhangs" in the alignment between R1 and R2 are trimmed off. "Overhangs" are when R2 extends past the start of R1, and vice-versa, as can happen when reads are longer than the amplicon and read into the other-direction primer region. Default="F" (false)
 
     Other arguments:
+      --dadaOpt.XXX                 Set as e.g. --dadaOpt.HOMOPOLYMER_GAP_PENALTY=-1 Options for the dada function, see ?setDadaOpt in R for available options and their defaults
       --pool                        Should sample pooling be used to aid identification of low-abundance ASVs? Options are  pseudo pooling: "pseudo", true: "T", false: "F"
       --outdir                      The output directory where the results will be saved
       --email                       Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits
@@ -71,7 +72,7 @@ A dada2-based workflow using the Nextflow workflow manager.  The basic pipeline 
 
 ## Prerequisites
 
-Nextflow, dada2 (>= 1.8), R (>= 3.2.0), Rcpp (>= 0.11.2), methods (>= 3.2.0), DECIPHER, phangorn, biomformat
+Nextflow (>=20.11.0), dada2 (>= 1.8), R (>= 3.2.0), Rcpp (>= 0.11.2), methods (>= 3.2.0), DECIPHER, phangorn, biomformat
 Note: if you are working on UCT hex you can simply use the singularity image specified in the uct_hex profile (no need to install these R packages)
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A dada2-based workflow using the Nextflow workflow manager.  The basic pipeline 
     This pipeline can be run specifying parameters in a config file or with command line flags.
 
     The typical example for running the pipeline with command line flags is as follows:
-    nextflow run uct-cbio/16S-rDNA-dada2-pipeline --reads '*_R{1,2}.fastq.gz' --trimFor 24 --trimRev 25 --reference 'gg_13_8_train_set_97.fa.gz' -profile uct_hex
+    nextflow run h3abionet/TADA --reads '*_R{1,2}.fastq.gz' --trimFor 24 --trimRev 25 --reference 'gg_13_8_train_set_97.fa.gz' -profile uct_hex
 
     The typical command for running the pipeline with your own config (instead of command line flags) is as follows:
-    nextflow run uct-cbio/16S-rDNA-dada2-pipeline -c dada2_user_input.config -profile uct_hex
+    nextflow run h3abionet/TADA -c dada2_user_input.config -profile uct_hex
     where:
     dada2_user_input.config is the configuration file (see example 'dada2_user_input.config')
     NB: -profile uct_hex still needs to be specified from the command line
@@ -58,7 +58,7 @@ A dada2-based workflow using the Nextflow workflow manager.  The basic pipeline 
       -name                         Name for the pipeline run. If not specified, Nextflow will automatically generate a random  mnemonic.
 
      Help:
-      --help                        Will print out summary above when executing nextflow run uct-cbio/16S-rDNA-dada2-pipeline                                   
+      --help                        Will print out summary above when executing nextflow run h3abionet/TADA                                   
 
      Example run:
      To run on UCT hex
@@ -66,7 +66,7 @@ A dada2-based workflow using the Nextflow workflow manager.  The basic pipeline 
      2) Start an interactive job using: qsub -I -q UCTlong -l nodes=1:series600:ppn=1 -d `pwd`
      3) A typical command would look something like:
 
-        nextflow run uct-cbio/16S-rDNA-dada2-pipeline --trimFor 24 --trimRev 25 --reference /specify/relevant/directory/gg_13_8_train_set_97.fa.gz --email katieviljoen@gmail.com -profile uct_hex --reads  '/specify/relevant/directory/*{R1,R2}.fastq' -with-singularity /scratch/DB/bio/singularity-containers/1a32017e5935-2018-05-31- db3a9cebe9fc.img --pool 'pseudo'
+        nextflow run h3abionet/TADA --trimFor 24 --trimRev 25 --reference /specify/relevant/directory/gg_13_8_train_set_97.fa.gz --email katieviljoen@gmail.com -profile uct_hex --reads  '/specify/relevant/directory/*{R1,R2}.fastq' -with-singularity /scratch/DB/bio/singularity-containers/1a32017e5935-2018-05-31- db3a9cebe9fc.img --pool 'pseudo'
 
 
 ## Prerequisites
@@ -75,7 +75,7 @@ Nextflow, dada2 (>= 1.8), R (>= 3.2.0), Rcpp (>= 0.11.2), methods (>= 3.2.0), DE
 Note: if you are working on UCT hex you can simply use the singularity image specified in the uct_hex profile (no need to install these R packages)
 
 ## Documentation
-The uct-cbio/16S-rDNA-dada2-pipeline pipeline comes with documentation about the pipeline, found in the `docs/` directory:
+The h3abionet/TADA pipeline comes with documentation about the pipeline, found in the `docs/` directory:
 
 1. [Installation](docs/installation.md)
 2. [Running the pipeline](docs/usage.md)

--- a/bin/MergePairs-Pooled.R
+++ b/bin/MergePairs-Pooled.R
@@ -13,10 +13,12 @@ option_list = list(
     make_option(c("--trimOverhang"), default=FALSE, action="store_true", help="Trim overhanging sequence if overlapping"),
     make_option(c("--justConcatenate"), default=FALSE, action="store_true", help="Just concatenate sequences"),
     make_option(c("--minMergedLen"), type="numeric", default=1, help="Minimum length post merging"),
-    make_option(c("--maxMergedLen"), type="numeric", default=Inf, help="Maximum length post merging")
+    make_option(c("--maxMergedLen"), type="numeric", default=Inf, help="Maximum length post merging"),
+    make_option(c("--dadaOptStr"), type="character", default='', help="values for setDadaOpt passed as one string")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
+eval(parse(text=paste0("setDadaOpt(", opt$dadaOptStr, ")")))
 
 filtFs <- list.files('.', pattern="R1.filtered.fastq.gz", full.names = TRUE)
 filtRs <- list.files('.', pattern="R2.filtered.fastq.gz", full.names = TRUE)

--- a/bin/MergePairs.R
+++ b/bin/MergePairs.R
@@ -7,7 +7,6 @@ option_list = list(
     make_option(c("--errRev"), type="character", default=NULL, help="Reverse RDS file"),
     make_option(c("--cpus"), type="numeric", , default=1, help="cpus"),
     make_option(c("--pool"), type="character", help="Pooling"),
-
     make_option(c("--minOverlap"), type="numeric", help="Min overlap"),
     make_option(c("--maxMismatch"), type="numeric", help="Max mismatch"),
     make_option(c("--trimOverhang"), default=FALSE, action="store_true", help="Trim overhanging sequence if overlapping"),

--- a/bin/MergePairs.R
+++ b/bin/MergePairs.R
@@ -11,10 +11,12 @@ option_list = list(
     make_option(c("--minOverlap"), type="numeric", help="Min overlap"),
     make_option(c("--maxMismatch"), type="numeric", help="Max mismatch"),
     make_option(c("--trimOverhang"), default=FALSE, action="store_true", help="Trim overhanging sequence if overlapping"),
-    make_option(c("--justConcatenate"), default=FALSE, action="store_true", help="Just concatenate sequences")
+    make_option(c("--justConcatenate"), default=FALSE, action="store_true", help="Just concatenate sequences"),
+    make_option(c("--dadaOptStr"), type="character", default='', help="values for setDadaOpt passed as one string")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
+eval(parse(text=paste0("setDadaOpt(", opt$dadaOptStr, ")")))
 
 environment(mergePairsRescue) <- asNamespace('dada2')
 

--- a/bin/VariableLenMergePairs-Pooled.R
+++ b/bin/VariableLenMergePairs-Pooled.R
@@ -15,9 +15,11 @@ option_list = list(
     make_option(c("--rescueUnmerged"), default=FALSE, action="store_true", help="Rescue unmerged sequences"),
     make_option(c("--minMergedLen"), type="numeric", default=1, help="Minimum length post merging"),
     make_option(c("--maxMergedLen"), type="numeric", default=Inf, help="Maximum length post merging")    
+    make_option(c("--dadaOptStr"), type="character", default='', help="values for setDadaOpt passed as one string")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
+eval(parse(text=paste0("setDadaOpt(", opt$dadaOptStr, ")")))
 
 # Note: this is a modified copy of the default mergePairs() method; this can
 # retain unmerged reads in case they don't overlap (this happens with some

--- a/main.nf
+++ b/main.nf
@@ -54,6 +54,7 @@ def helpMessage() {
                                     "Overhangs" are when R2 extends past the start of R1, and vice-versa, as can happen when reads are longer than the amplicon and read into the other-direction                                               primer region. Default="F" (false)
 
     Other arguments:
+      --dadaOpt.XXX                 Set as e.g. --dadaOpt.HOMOPOLYMER_GAP_PENALTY=-1 Global defaults for the dada function, see ?setDadaOpt in R for available options and their defaults
       --pool                        Should sample pooling be used to aid identification of low-abundance ASVs? Options are
                                     pseudo pooling: "pseudo", true: "T", false: "F"
       --outdir                      The output directory where the results will be saved
@@ -154,7 +155,8 @@ summary['rmPhiX']         = params.rmPhiX
 summary['minOverlap']     = params.minOverlap
 summary['maxMismatch']    = params.maxMismatch
 summary['trimOverhang']   = params.trimOverhang
-summary['species']  	  = params.species
+summary['species']        = params.species
+summary['dadaOpt']        = params.dadaOpt
 summary['pool']           = params.pool
 summary['qualityBinning'] = params.qualityBinning
 summary['Reference']      = params.reference
@@ -487,6 +489,7 @@ process LearnErrorsFor {
     #!/usr/bin/env Rscript
     library(dada2);
     packageVersion("dada2")
+    setDadaOpt(${params.dadaOpt.collect{k,v->"$k=$v"}.join(", ")})
 
     # File parsing
     filtFs <- list.files('.', pattern="R1.filtered.fastq.gz", full.names = TRUE)
@@ -529,6 +532,7 @@ process LearnErrorsRev {
     #!/usr/bin/env Rscript
     library(dada2);
     packageVersion("dada2")
+    setDadaOpt(${params.dadaOpt.collect{k,v->"$k=$v"}.join(", ")})
 
     # load error profiles
 
@@ -652,6 +656,7 @@ if (params.pool == "T" || params.pool == 'pseudo') {
         #!/usr/bin/env Rscript
         library(dada2)
         packageVersion("dada2")
+        setDadaOpt(${params.dadaOpt.collect{k,v->"$k=$v"}.join(", ")})
 
         errF <- readRDS("${errFor}")
         errR <- readRDS("${errRev}")

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,7 +57,8 @@ params {
     trimOverhang = "F" // KL: I don't think we have overhangs for WISH project03
     justConcatenate = "F"  // TODO: test using false instead of string
     rescueUnmerged = false // CF: this is for rescuing unmerged ITS, should be off unless really needed
-    dadaParams = false // if set, these are additional arguments passed to the dada() function !!!Experimental!!!
+    dadaParams = false // if set, these are additional arguments passed to the dada() function in the PacBio workflow !!!Deprecated!!!
+    dadaOpt = []
     maxMergedLen = 0 // Only run if set > 1
     minMergedLen = 0 // Only run if set > 1
     // Renaming

--- a/pacbio.nf
+++ b/pacbio.nf
@@ -54,6 +54,7 @@ def helpMessage() {
                                     "Overhangs" are when R2 extends past the start of R1, and vice-versa, as can happen when reads are longer than the amplicon and read into the other-direction                                               primer region. Default="F" (false)
 
     Other arguments:
+      --dadaOpt.XXX                 Set as e.g. --dadaOpt.HOMOPOLYMER_GAP_PENALTY=-1 Global defaults for the dada function, see ?setDadaOpt in R for available options and their defaults
       --pool                        Should sample pooling be used to aid identification of low-abundance ASVs? Options are
                                     pseudo pooling: "pseudo", true: "T", false: "F"
       --outdir                      The output directory where the results will be saved
@@ -356,6 +357,7 @@ process PacBioLearnErrors {
     sample.namesF <- sapply(strsplit(basename(filts), "_"), `[`, 1) # Assumes filename = samplename_XXX.fastq.gz
     set.seed(100)
  
+    setDadaOpt(${params.dadaOpt.collect{k,v->"$k=$v"}.join(", ")})
     # Learn forward error rates
     errs <- learnErrors(filts, 
         errorEstimationFunction=PacBioErrfun, 
@@ -422,6 +424,7 @@ process PacBioPoolSamplesInferDerep {
 
     dereps <- derepFastq(filts, qualityType = "FastqQuality", verbose=TRUE)
 
+    setDadaOpt(${params.dadaOpt.collect{k,v->"$k=$v"}.join(", ")})
     dds <- dada(dereps, err=errs, multithread=${task.cpus}, pool=pool ${dadaParams})
 
     # TODO: make this a single item list with ID as the name, this is lost


### PR DESCRIPTION
This change allows running the pipeline on 454 data, issue https://github.com/h3abionet/TADA/issues/6.

I've tested the whole pipeline by:
- running a small test run on the current version
- running the same run on the changed version and verifying errorsF.RDS and seqtab_original.RDS are the same
- specifying slightly different alignment parameters (`--dadaOpt.GAP_PENALTY -10` \ etc.)  and verifying errorsF.RDS and seqtab_original.RDS have slightly changed

For the mad optparse + eval line added to R scripts, I've checked that the following program works:
```
#!/usr/bin/env Rscript
suppressPackageStartupMessages(library(dada2))
suppressPackageStartupMessages(library(optparse))
option_list = list(
    make_option(c("--dadaOptStr"), type="character", default='', help="values for setDadaOpt passed as one string")
)
opt <- parse_args(OptionParser(option_list=option_list))
eval(parse(text=paste0("setDadaOpt(", opt$dadaOptStr, ")")))
getDadaOpt()
```